### PR TITLE
COMDOX-365: Add redirects

### DIFF
--- a/docs/backward-incompatible-changes.md
+++ b/docs/backward-incompatible-changes.md
@@ -1,6 +1,6 @@
 ---
 title: MFTF 3.0.0 backward incompatible changes
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/backward-incompatible-changes/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/backward-incompatible-changes/
 layout: migrated
 ---
 

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -1,6 +1,6 @@
 ---
 title: Best practices
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/test-writing/best-practices/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/test-writing/best-practices/
 layout: migrated
 ---
 

--- a/docs/commands/codeception.md
+++ b/docs/commands/codeception.md
@@ -1,6 +1,6 @@
 ---
 title: CLI commands - vendor/bin/codecept
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/commands/codeception/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/commands/codeception/
 layout: migrated
 ---
 

--- a/docs/commands/mftf.md
+++ b/docs/commands/mftf.md
@@ -1,6 +1,6 @@
 ---
 title: CLI commands - vendor/bin/mftf
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/commands/mftf/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/commands/mftf/
 layout: migrated
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Configuration
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/configuration/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/configuration/
 layout: migrated
 ---
 

--- a/docs/configure-2fa.md
+++ b/docs/configure-2fa.md
@@ -1,6 +1,6 @@
 ---
 title: Configuring MFTF for two-factor authentication (2FA)
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/two-factor-authentication/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/two-factor-authentication/
 layout: migrated
 ---
 

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -1,6 +1,6 @@
 ---
 title: Credentials
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/credentials/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/credentials/
 layout: migrated
 ---
 

--- a/docs/custom-helpers.md
+++ b/docs/custom-helpers.md
@@ -1,6 +1,6 @@
 ---
 title: Custom helpers
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/custom-helpers/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/custom-helpers/
 layout: migrated
 ---
 

--- a/docs/data.md
+++ b/docs/data.md
@@ -1,6 +1,6 @@
 ---
 title: Input testing data
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/data/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/data/
 layout: migrated
 ---
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -1,6 +1,6 @@
 ---
 title: Debugging
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/debugging/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/debugging/
 layout: migrated
 ---
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -1,6 +1,6 @@
 ---
 title: Extending
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/extending/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/extending/
 layout: migrated
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 ---
 title: Getting started
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/getting-started/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/getting-started/
 layout: migrated
 ---
 

--- a/docs/guides/action-groups.md
+++ b/docs/guides/action-groups.md
@@ -1,6 +1,6 @@
 ---
 title: Action group best practices
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/test/action-group-best-practices/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/test/action-group-best-practices/
 layout: migrated
 ---
 

--- a/docs/guides/cicd.md
+++ b/docs/guides/cicd.md
@@ -1,6 +1,6 @@
 ---
 title: How to use MFTF in CICD
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/cicd/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/cicd/
 layout: migrated
 ---
 

--- a/docs/guides/git-vs-composer-install.md
+++ b/docs/guides/git-vs-composer-install.md
@@ -1,6 +1,6 @@
 ---
 title: Git vs Composer installation of Magento with MFTF
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/git-vs-composer-install/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/git-vs-composer-install/
 layout: migrated
 ---
 

--- a/docs/guides/selectors.md
+++ b/docs/guides/selectors.md
@@ -1,6 +1,6 @@
 ---
 title: How to write good selectors
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/test-writing/selectors/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/test-writing/selectors/
 layout: migrated
 ---
 

--- a/docs/guides/test-isolation.md
+++ b/docs/guides/test-isolation.md
@@ -1,6 +1,6 @@
 ---
 title: Test isolation
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/test-writing/test-isolation/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/test-writing/test-isolation/
 layout: migrated
 ---
 

--- a/docs/guides/test-modularity.md
+++ b/docs/guides/test-modularity.md
@@ -1,6 +1,6 @@
 ---
 title: Test modularity
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/test-writing/test-modularity/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/test-writing/test-modularity/
 layout: migrated
 ---
 

--- a/docs/guides/using-suites.md
+++ b/docs/guides/using-suites.md
@@ -1,6 +1,6 @@
 ---
 title: Using suites
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/test-writing/using-suites/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/test-writing/using-suites/
 layout: migrated
 ---
 

--- a/docs/interactive-pause.md
+++ b/docs/interactive-pause.md
@@ -1,6 +1,6 @@
 ---
 title: Interactive pause
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/interactive-pause/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/interactive-pause/
 layout: migrated
 ---
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,6 +1,6 @@
 ---
 title: Introduction to the Magento Functional Testing Framework
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/
 layout: migrated
 ---
 

--- a/docs/merge_points/extend-action-groups.md
+++ b/docs/merge_points/extend-action-groups.md
@@ -1,6 +1,6 @@
 ---
 title: Extend action groups
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/merge-points/extend-action-groups/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/merge-points/extend-action-groups/
 layout: migrated
 ---
 

--- a/docs/merge_points/extend-data.md
+++ b/docs/merge_points/extend-data.md
@@ -1,6 +1,6 @@
 ---
 title: Extend data entities
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/merge-points/extend-data/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/merge-points/extend-data/
 layout: migrated
 ---
 

--- a/docs/merge_points/extend-tests.md
+++ b/docs/merge_points/extend-tests.md
@@ -1,6 +1,6 @@
 ---
 title: Extend tests
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/merge-points/extend-tests/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/merge-points/extend-tests/
 layout: migrated
 ---
 

--- a/docs/merge_points/introduction.md
+++ b/docs/merge_points/introduction.md
@@ -1,6 +1,6 @@
 ---
 title: Merge points for testing extensions in MFTF
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/merge-points/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/merge-points/
 layout: migrated
 ---
 

--- a/docs/merge_points/merge-action-groups.md
+++ b/docs/merge_points/merge-action-groups.md
@@ -1,6 +1,6 @@
 ---
 title: Merge action groups
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/merge-points/merge-action-groups/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/merge-points/merge-action-groups/
 layout: migrated
 ---
 

--- a/docs/merge_points/merge-data.md
+++ b/docs/merge_points/merge-data.md
@@ -1,6 +1,6 @@
 ---
 title: Merge data
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/merge-points/merge-data/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/merge-points/merge-data/
 layout: migrated
 ---
 

--- a/docs/merge_points/merge-pages.md
+++ b/docs/merge_points/merge-pages.md
@@ -1,6 +1,6 @@
 ---
 title: Merge pages
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/merge-points/merge-pages/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/merge-points/merge-pages/
 layout: migrated
 ---
 

--- a/docs/merge_points/merge-sections.md
+++ b/docs/merge_points/merge-sections.md
@@ -1,6 +1,6 @@
 ---
 title: Merge sections
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/merge-points/merge-sections/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/merge-points/merge-sections/
 layout: migrated
 ---
 

--- a/docs/merge_points/merge-tests.md
+++ b/docs/merge_points/merge-tests.md
@@ -1,6 +1,6 @@
 ---
 title: Merge tests
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/merge-points/merge-tests/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/merge-points/merge-tests/
 layout: migrated
 ---
 

--- a/docs/merging.md
+++ b/docs/merging.md
@@ -1,6 +1,6 @@
 ---
 title: Merging
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/merging/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/merging/
 layout: migrated
 ---
 

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -1,6 +1,6 @@
 ---
 title: Metadata
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/metadata/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/metadata/
 layout: migrated
 ---
 

--- a/docs/mftf-tests-packaging.md
+++ b/docs/mftf-tests-packaging.md
@@ -1,6 +1,6 @@
 ---
 title: MFTF functional test modules and packaging
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/mftf-tests-packaging/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/mftf-tests-packaging/
 layout: migrated
 ---
 

--- a/docs/page.md
+++ b/docs/page.md
@@ -1,6 +1,6 @@
 ---
 title: Page structure
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/page/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/page/
 layout: migrated
 ---
 

--- a/docs/reporting.md
+++ b/docs/reporting.md
@@ -1,6 +1,6 @@
 ---
 title: Reporting
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/reporting/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/reporting/
 layout: migrated
 ---
 

--- a/docs/section.md
+++ b/docs/section.md
@@ -1,6 +1,6 @@
 ---
 title: Section structure
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/section/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/section/
 layout: migrated
 ---
 

--- a/docs/section/locator-functions.md
+++ b/docs/section/locator-functions.md
@@ -1,6 +1,6 @@
 ---
 title: Locator functions
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/section/locator-functions/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/section/locator-functions/
 layout: migrated
 ---
 

--- a/docs/section/parameterized-selectors.md
+++ b/docs/section/parameterized-selectors.md
@@ -1,6 +1,6 @@
 ---
 title: Parameterized selectors
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/section/parameterized-selectors/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/section/parameterized-selectors/
 layout: migrated
 ---
 

--- a/docs/selectors.md
+++ b/docs/selectors.md
@@ -1,6 +1,6 @@
 ---
 title: Selectors
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/test-writing/selectors/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/test-writing/selectors/
 layout: migrated
 ---
 

--- a/docs/suite.md
+++ b/docs/suite.md
@@ -1,6 +1,6 @@
 ---
 title: Suites
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/suite/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/suite/
 layout: migrated
 ---
 

--- a/docs/test-prep.md
+++ b/docs/test-prep.md
@@ -1,6 +1,6 @@
 ---
 title: Preparing a test for MFTF
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/test-writing/test-prep/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/test-writing/test-prep/
 layout: migrated
 ---
 

--- a/docs/test.md
+++ b/docs/test.md
@@ -1,6 +1,6 @@
 ---
 title: Test
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/test/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/test/
 layout: migrated
 ---
 

--- a/docs/test/action-groups.md
+++ b/docs/test/action-groups.md
@@ -1,6 +1,6 @@
 ---
 title: Action groups
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/test/action-groups/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/test/action-groups/
 layout: migrated
 ---
 

--- a/docs/test/actions.md
+++ b/docs/test/actions.md
@@ -1,6 +1,6 @@
 ---
 title: Test actions
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/test/actions/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/test/actions/
 layout: migrated
 ---
 

--- a/docs/test/annotations.md
+++ b/docs/test/annotations.md
@@ -1,6 +1,6 @@
 ---
 title: Annotations
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/test/annotations/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/test/annotations/
 layout: migrated
 ---
 

--- a/docs/test/assertions.md
+++ b/docs/test/assertions.md
@@ -1,6 +1,6 @@
 ---
 title: Assertions
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/test/assertions/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/test/assertions/
 layout: migrated
 ---
 

--- a/docs/tips-tricks.md
+++ b/docs/tips-tricks.md
@@ -1,6 +1,6 @@
 ---
 title: Tips and tricks
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/test-writing/tips-tricks/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/test-writing/tips-tricks/
 layout: migrated
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,6 +1,6 @@
 ---
 title: Troubleshooting
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/troubleshooting/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/troubleshooting/
 layout: migrated
 ---
 

--- a/docs/update.md
+++ b/docs/update.md
@@ -1,6 +1,6 @@
 ---
 title: Update the Magento Functional Testing Framework
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/update/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/update/
 layout: migrated
 ---
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,6 +1,6 @@
 ---
 title: MFTF versioning schema
-migrated_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/versioning/
+redirect_to: https://developer.adobe.com/commerce/testing/functional-testing-framework/versioning/
 layout: migrated
 ---
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) replaces the `migrated_to:` metadata with `redirect_to:` so that we can redirect to the new Adobe sites.

- **Jira**: COMDOX-365
- **Staging**: https://devdocs.magedevteam.com/792
- **Related to**:
   - https://github.com/magento-commerce/devdocs/pull/3225
   - https://github.com/magento-commerce/pagebuilder-docs/pull/24
   - https://github.com/magento-commerce/devdocs-mbi/pull/14